### PR TITLE
Replaced form with formspree

### DIFF
--- a/src/components/ContactPage.vue
+++ b/src/components/ContactPage.vue
@@ -9,7 +9,7 @@
         <div id="form_inner">
           <form
             id="form"
-            action="https://formsubmit.co/el/bulixe"
+            action="https://formspree.io/f/mjvdnenz"
             method="POST"
           >
             <div id="form_title_parent">
@@ -30,7 +30,7 @@
                 required
                 placeholder="Your email..."
                 class="input"
-                type="text"
+                type="email"
                 id="email"
                 name="email"
               />

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -118,7 +118,7 @@
           <div id="form_inner">
             <form
               id="form"
-              action="https://formsubmit.co/el/bulixe"
+              action="https://formspree.io/f/mjvdnenz"
               method="POST"
             >
               <div id="form_title_parent">


### PR DESCRIPTION
Replaced contact form with a Formspree form temporarily to get it working until we can look into sending emails from the backend